### PR TITLE
If same src/dest don't overwrite file if line endings already normalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ grunt.initConfig({
 });
 ```
 
+
+#### Convert files in place (overwrite)
+Set `overwrite` option to true. This ignored the destination (set it to `''`) and overwrites the sources files. Additionally it only overwrites the src files if the line endings have changed.
+
+```js
+grunt.initConfig({
+  lineending: {
+    dist: {
+      options: {
+        overwrite: true
+      },
+      files: {
+        '': ['test/fixtures/*']
+      }
+    }
+  }
+});
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/lineending.js
+++ b/tasks/lineending.js
@@ -35,30 +35,36 @@ module.exports = function(grunt) {
         linefeed = detectLineFeed(options.eol)
       }
 
-      var hasChanged = true;
+      // src and dest are the same file (defaults to false)
+      var overwrite = options.overwrite || false;
 
       var src = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
           grunt.log.warn('Source file "' + filepath + '" not found.');
           return false;
+        } else {
+          return true;
         }
-
-        // ignore files that already have normalized line endings
-        var original = grunt.file.read(filepath);
-        var expected = lineEnding(filepath, linefeed);
-        if (original == expected) {
-          hasChanged = false;
-        }
-  
-        return true;
       });
 
       // create output
       var output = [];
       src.forEach(function(_src){
         try {
-          output.push(lineEnding(_src, linefeed));
+          var normalized = lineEnding(_src, linefeed);
+          output.push(normalized);
+          if (overwrite) {
+            // ignore files if input/output is the same
+            var original = grunt.file.read(_src);
+            if (original != normalized) {
+              // Write the destination file.
+              grunt.file.write(_src, normalized);
+         
+              // Print a success message.
+              grunt.log.writeln('File "' + _src + '" updated.');
+            }
+          }
         } catch (e) {
           var err = new Error('Uglification failed.');
           err.origError = e;
@@ -66,14 +72,14 @@ module.exports = function(grunt) {
         }
       })
 
-      // Skip if src and destination are the same and there is no change
-      if (f.src[0] != f.dest && hasChanged) {
+      if (!overwrite) {
         // Write the destination file.
         grunt.file.write(f.dest, output.join(linefeed));
-
+   
         // Print a success message.
         grunt.log.writeln('File "' + f.dest + '" created.');
       }
+
     });
   });
 };


### PR DESCRIPTION
If the src and dest are the same, updating files even when line endings are already normalized, has undesirable side effects. Among other things, it triggers watch, causes IDE to reload and flush undo/redo history, modifies mtime which is relied for cache busting, etc.

It is fairly common use-case to normalize the files in-place using options:

```
…
src: ['foo/*'],
rename: function(dest, src) {
  return src;
},
…
```
