### PR TITLE
Add overwrite option to update source files in-place

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ grunt.initConfig({
 });
 ```
 
+#### Convert files in-place (overwrite)
+Set `overwrite` option to `true` (default is `false`). The destination is ignored and can be set to `''`.
+
+This option only overwrites a source file if the line endings need to be updated otherwise it leaves the file untouched.
+
+```js
+grunt.initConfig({
+  lineending: {
+    dist: {
+      options: {
+        overwrite: true
+      },
+      files: {
+        '': ['test/fixtures/*']
+      }
+    }
+  }
+});
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/lineending.js
+++ b/tasks/lineending.js
@@ -28,6 +28,10 @@ module.exports = function(grunt) {
     });
     grunt.verbose.writeflags(options, 'Options');
     this.files.forEach(function(f) {
+
+      // src and dest are the same file (defaults to false)
+      var overwrite = options.overwrite || false;
+
       var src = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
@@ -48,7 +52,19 @@ module.exports = function(grunt) {
       var output = [];
       src.forEach(function(_src){
         try {
-          output.push(lineEnding(_src, linefeed));
+          var normalized = lineEnding(_src, linefeed);
+          output.push(normalized);
+          if (overwrite) {
+            // ignore files if input/output is the same
+            var original = grunt.file.read(_src);
+            if (original != normalized) {
+              // Write the destination file.
+              grunt.file.write(_src, normalized);
+         
+              // Print a success message.
+              grunt.log.writeln('File "' + _src + '" updated.');
+            }
+          }
         } catch (e) {
           var err = new Error('Uglification failed.');
           err.origError = e;
@@ -56,11 +72,14 @@ module.exports = function(grunt) {
         }
       })
 
-      // Write the destination file.
-      grunt.file.write(f.dest, output.join(linefeed));
- 
-      // Print a success message.
-      grunt.log.writeln('File "' + f.dest + '" created.');
+      if (!overwrite) {
+        // Write the destination file.
+        grunt.file.write(f.dest, output.join(linefeed));
+   
+        // Print a success message.
+        grunt.log.writeln('File "' + f.dest + '" created.');
+      }
+
     });
   });
 };


### PR DESCRIPTION
Ignore the earlier pull request. I had some time to write this up cleanly and update the readme.

The impact on performance is negligible since the input and output are already computed as per default behavior. I just do an equality check before overwriting the source.
