### PR TITLE
Skip non files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+test/expected/multi/bar eol=lf
+test/expected/multi/foo eol=lf
+test/expected/nested/one eol=lf
+test/expected/nested/level1/nest_one eol=lf
+test/expected/nested/level1/level2/nest_two eol=lf
+test/expected/crlf eol=crlf
+test/expected/lf eol=lf
+test/expected/multi_cat eol=lf
+test/fixtures/multi/bar eol=crlf
+test/fixtures/multi/foo eol=crlf
+test/fixtures/nested/one eol=crlf
+test/fixtures/nested/level1/nest_one eol=crlf
+test/fixtures/nested/level1/level2/nest_two eol=crlf
+test/fixtures/crlf eol=crlf
+test/fixtures/lf eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp/
+node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,14 @@ module.exports = function(grunt) {
         files : {
           "./tmp/multi_cat" : ["test/fixtures/multi/*"]
         }
+      },
+      nested : {
+        files : [{
+          expand : true,
+          cwd : './test/fixtures/nested',
+          src : ['**/*'],
+          dest : 'tmp/nested'
+        }]
       }
     },
 

--- a/tasks/lineending.js
+++ b/tasks/lineending.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       case "lf":
         return '\n';
     }
-  }
+  };
   var lineEnding = function(filepath, linefeed){
     var file = grunt.file.read(filepath);
     
@@ -37,15 +37,21 @@ module.exports = function(grunt) {
         if (!grunt.file.exists(filepath)) {
           grunt.log.warn('Source file "' + filepath + '" not found.');
           return false;
+        } else if (!grunt.file.isFile(filepath)) {
+          grunt.verbose.writeln('Skipping "' + filepath + '" not a file.');
+          return false;
         } else {
           return true;
         }
       });
+      if (src.length === 0) {
+        return;
+      }
     
       // detect linefeed
       var linefeed  = '\n';
       if(options.eol){
-        linefeed = detectLineFeed(options.eol)
+        linefeed = detectLineFeed(options.eol);
       }
 
       // create output
@@ -66,11 +72,11 @@ module.exports = function(grunt) {
             }
           }
         } catch (e) {
-          var err = new Error('Uglification failed.');
+          var err = new Error('Linefeed convert failed.');
           err.origError = e;
           grunt.fail.warn(err);
         }
-      })
+      });
 
       if (!overwrite) {
         // Write the destination file.

--- a/test/expected/nested/level1/level2/nest_two
+++ b/test/expected/nested/level1/level2/nest_two
@@ -1,0 +1,4 @@
+message
+message
+message
+message

--- a/test/expected/nested/level1/nest_one
+++ b/test/expected/nested/level1/nest_one
@@ -1,0 +1,2 @@
+message
+message

--- a/test/expected/nested/one
+++ b/test/expected/nested/one
@@ -1,0 +1,3 @@
+message
+message
+message

--- a/test/fixtures/nested/level1/level2/nest_two
+++ b/test/fixtures/nested/level1/level2/nest_two
@@ -1,0 +1,4 @@
+message
+message
+message
+message

--- a/test/fixtures/nested/level1/nest_one
+++ b/test/fixtures/nested/level1/nest_one
@@ -1,0 +1,2 @@
+message
+message

--- a/test/fixtures/nested/one
+++ b/test/fixtures/nested/one
@@ -1,0 +1,3 @@
+message
+message
+message

--- a/test/lineending_test.js
+++ b/test/lineending_test.js
@@ -71,10 +71,29 @@ exports.test = {
     test.equal(grunt.file.read(dir+'/multi/baz'), expected, 'multi : baz');
     test.done();
   },
-  multi_cat : function(test){
+  multi_cat: function(test) {
     test.expect(1);
     var expected = grunt.file.read('test/expected/multi_cat');
     test.equal(grunt.file.read('tmp/multi_cat'), expected, 'multi cat');
+    test.done();
+  },
+  nested: function (test) {
+    test.expect(3);
+    test.equal(
+      grunt.file.read('tmp/nested/one'),
+      grunt.file.read('test/expected/nested/one'),
+      'base file'
+    );
+    test.equal(
+      grunt.file.read('tmp/nested/level1/nest_one'),
+      grunt.file.read('test/expected/nested/level1/nest_one'),
+      'nest level one'
+    );
+    test.equal(
+      grunt.file.read('tmp/nested/level1/level2/nest_two'),
+      grunt.file.read('test/expected/nested/level1/level2/nest_two'),
+      'nest level two'
+    );
     test.done();
   }
 };


### PR DESCRIPTION
This allows to use nested folders in the source file list.

Add also a .gitatributes to specify exactly which file has which line ending. Without this file, on windows + autocrlf git will convert all `lf` into `crlf` automatically.

This fixes #8 
