### PR TITLE
[bc/break] Use grunt.util.linefeed as default line break character

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In your project's Gruntfile, add a section named `lineending` to the data object
 #### eol
 Type: `String`  
 Choices: `'lf'`, `'cr'`, `'crlf'`  
-Default: `'lf'`  
+Default: `grunt.util.linefeed` value  
 
 ### Usage Examples
 

--- a/tasks/lineending.js
+++ b/tasks/lineending.js
@@ -15,6 +15,8 @@ module.exports = function(grunt) {
         return '\r\n';
       case "lf":
         return '\n';
+      default:
+        return grunt.util.linefeed;
     }
   };
   var lineEnding = function(filepath, linefeed){
@@ -49,10 +51,7 @@ module.exports = function(grunt) {
       }
     
       // detect linefeed
-      var linefeed  = '\n';
-      if(options.eol){
-        linefeed = detectLineFeed(options.eol);
-      }
+      var linefeed  = detectLineFeed(options.eol);
 
       // create output
       var output = [];

--- a/test/lineending_test.js
+++ b/test/lineending_test.js
@@ -26,6 +26,7 @@ exports.test = {
   setUp: function(done) {
     // setup here if necessary
     done();
+    grunt.util.linefeed = '\n';
   },
   default_options: function(test) {
     test.expect(1);


### PR DESCRIPTION
This follows the facto standard of use `grunt.util.linefeed` for configure the line ending characters
